### PR TITLE
Suggestion for syntax improvement

### DIFF
--- a/names.yml
+++ b/names.yml
@@ -1,11 +1,13 @@
 # This file lists one4ones. Please add your own! Below is an example one4one:
   
 # - name: "Joe Smith"
-#   handle: "@JoeSmith89389"
+#   handle: "JoeSmith89389"
 #   oneforone: "Jane Williams"
-#   oneforonehandle: "@JaneWilliams895464"
+#   oneforonehandle: "JaneWilliams895464"
+#   oneforoneplatform: "https://twitter.com/" 
 
-- name: "Erie Meyer
-  handle: "@erie"
+- name: "Erie Meyer"
+  handle: "erie"
   oneforone: "Aminatou Sow"
-  oneforonehandle: "@Aminatou"
+  oneforonehandle: "Aminatou"
+  oneforoneplatform: "https://twitter.com"


### PR DESCRIPTION
To enable flexible call outs on a variety of platforms, a very small syntax change could help and also enable value added platforms consuming this data in the future. If we capture the platform the handles are on, we increase the discoverability of the oneforones. Plus, we can then create code that just applies the handle to the URL of the platform to go to the direct link (oneoronehandle + oneforoneplatform).
