### PR TITLE
Make oneforone an object

### DIFF
--- a/names.yml
+++ b/names.yml
@@ -2,7 +2,8 @@
   
 # - name: "Joe Smith"
 #   handle: "JoeSmith89389"
-#   oneforone: "Jane Williams"
+#   oneforone: 
+#     name: "Jane Williams"
 #     handle: "JaneWilliams895464"
 #     platform: "https://twitter.com"
 

--- a/names.yml
+++ b/names.yml
@@ -8,13 +8,15 @@
 
 - name: "Erie Meyer"
   handle: "erie"
-  oneforone: "Aminatou Sow"
+  oneforone: 
+    name: "Aminatou Sow"
     handle: "Aminatou"
     platform: "https://twitter.com/"
   
 - name: "Noah Kunin"
   handle: "noahkunin"
-  oneforone: "Laurenellen McCann"
+  oneforone: 
+    name:  "Laurenellen McCann"
     handle: "elle_mccann"
     platform: "https://twitter.com/"
 

--- a/names.yml
+++ b/names.yml
@@ -3,18 +3,18 @@
 # - name: "Joe Smith"
 #   handle: "JoeSmith89389"
 #   oneforone: "Jane Williams"
-#   oneforonehandle: "JaneWilliams895464"
-#   oneforoneplatform: "https://twitter.com"
+#     handle: "JaneWilliams895464"
+#     platform: "https://twitter.com"
 
 - name: "Erie Meyer"
   handle: "erie"
   oneforone: "Aminatou Sow"
-  oneforonehandle: "Aminatou"
-  oneforoneplatform: "https://twitter.com/"
+    handle: "Aminatou"
+    platform: "https://twitter.com/"
   
 - name: "Noah Kunin"
   handle: "noahkunin"
-  oneforone: "Laurenellen McCann
-  oneforonehandle: "elle_mccann"
-  oneforoneplatform: "https://twitter.com/"
+  oneforone: "Laurenellen McCann"
+    handle: "elle_mccann"
+    platform: "https://twitter.com/"
 


### PR DESCRIPTION
This pull request makes oneforone an object in `names.yml`, rather than using a bunch of prefixed, top-level keys. Object oriented programming FTW.
